### PR TITLE
corrected locals to use east in gcs backend and nodepool name changed…

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -2,7 +2,7 @@ module "gcs_buckets" {
   source          = "terraform-google-modules/cloud-storage/google"
   version         = "~> 3.4"
   project_id      = local.id
-  location        = local.region
+  location        = local.gs_region
   names           = ["terraform-state"]
   prefix          = local.name
   set_admin_roles = true

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,7 @@
 locals {
-  region = var.gcp_region
-  owner  = var.owner_email
-  name   = var.project_name
-  id     = var.project_id
+  region    = var.gcp_region
+  gs_region = var.gcs_region
+  owner     = var.owner_email
+  name      = var.project_name
+  id        = var.project_id
 }

--- a/node_pools.tf
+++ b/node_pools.tf
@@ -2,8 +2,8 @@ resource "google_service_account" "kubernetes" {
   account_id = "kubernetes"
 }
 
-resource "google_container_node_pool" "mlops_gke" {
-  name       = "mlops_gke"
+resource "google_container_node_pool" "mlops" {
+  name       = "mlops"
   cluster    = google_container_cluster.airflow.id
   node_count = 1
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@ variable "gcp_region" {
   default     = "us-central1"
 }
 
+variable "gcs_region" {
+  description = "Region for your GCS bucket is located in for storing tfstate files"
+  default     = "us-east1"
+}
+
 variable "owner_email" {
   description = "Owner email address"
   default     = "kevin.parasseril@gmail.com"


### PR DESCRIPTION
changed the following :
node pool name from mlops_gke to mlops as _is not allowed
kept gcs region as us-east1 as it was configured that way and not to tamper with the state file